### PR TITLE
Fix the path of libomp.dylib

### DIFF
--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -72,6 +72,9 @@ in stdenv.mkDerivation {
         otool -L $f
     done
     for f in $out/lib/*.dylib; do
+      if otool -L $f | grep "@rpath/libomp.dylib" >& /dev/null; then
+        install_name_tool -change "@rpath/libomp.dylib" ${llvmPackages.openmp}/lib/libomp.dylib $f
+      fi
       install_name_tool -id $out/lib/$(basename $f) $f || true
       for rpath in $(otool -L $f | grep rpath | awk '{print $1}');do
         install_name_tool -change $rpath $out/lib/$(basename $rpath) $f


### PR DESCRIPTION
You know that libtorch does not provide libomp.dylib and we  need to use `llvmPackages.openmp`. 
But `postFixup` replaced the rpath of libomp.dylib into libtorch's path not `llvmPackages.openmp`'s one.
This PR replaces the rpath of libomp.dylib into `llvmPackages.openmp`'s one.